### PR TITLE
Added support for rules as array

### DIFF
--- a/src/WithHtmlAttributes.php
+++ b/src/WithHtmlAttributes.php
@@ -21,7 +21,7 @@ trait WithHtmlAttributes
     public function formatRules()
     {
         $htmlAttributes = collect($this->rules())->map(function ($field) {
-            $this->rules = explode('|', $field);
+            $this->rules = is_array($field) ? $field : explode('|', $field);
             
             return array_map(function ($rule) {
                 $ruleArray = explode(':', $rule);

--- a/tests/WithHtmlAttributesRequestTest.php
+++ b/tests/WithHtmlAttributesRequestTest.php
@@ -125,4 +125,13 @@ class WithHtmlAttributesRequestTest extends TestCase
         
         $this->assertEquals($this->request->htmlAttributes()->link, "type=url");
     }
+
+    function test_it_returns_array_rules_as_html_attribute()
+    {
+        $this->request->setRules([
+            'name' => ['required', 'min:3'],
+        ]);
+
+        $this->assertEquals($this->request->htmlAttributes()->name, "required=required min=3");
+    }
 }


### PR DESCRIPTION
Rules in string `required|min:3` vs rules in an array: `['required', 'min:3']`